### PR TITLE
Fix compiler warning.

### DIFF
--- a/src/main/resources/archetype-resources/pom.xml
+++ b/src/main/resources/archetype-resources/pom.xml
@@ -20,7 +20,7 @@
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-stdlib-jre8</artifactId>
+            <artifactId>kotlin-stdlib-jdk8</artifactId>
             <version>${kotlin.version}</version>
         </dependency>
     </dependencies>


### PR DESCRIPTION
Noticed this when setting up a new project with the quickstart archetype:

![jdk8](https://user-images.githubusercontent.com/125509/53907177-a1d61500-401a-11e9-9fa4-b0e03f6d10e7.png)
